### PR TITLE
Add Dockerfile and update README with Docker instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code and any local `.env` for configuration
+COPY . .
+
+EXPOSE 8501
+
+# Launch the Streamlit dashboard
+CMD ["streamlit", "run", "app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # binance-analisys
- 
+
+## Docker
+
+1. Crie um arquivo `.env` na raiz do projeto com as variáveis necessárias (por exemplo, chaves da API da Binance).
+2. Construa a imagem Docker:
+
+   ```bash
+   docker build -t binance-analisys .
+   ```
+
+3. Execute o container carregando as variáveis do `.env` e expondo a porta do Streamlit:
+
+   ```bash
+   docker run --env-file .env -p 8501:8501 binance-analisys
+   ```
+
+O painel estará disponível em `http://localhost:8501`.


### PR DESCRIPTION
## Summary
- add a Dockerfile to run the Streamlit dashboard with environment variables provided via a local `.env`
- document Docker build and run steps in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688eefdbf088832b95245835c62075a1